### PR TITLE
Added clock + support for NTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ A tiny dashboard for Home Assistant, which you can build for yourself with a Ras
 * Ability to control up to 3 devices in Home Assistant per page, using A/B/X buttons on the display as toggle controls.
 * Device names + icons ([see below](#Icons)) are pulled from Home Assistant API, and highlight based on state (on/off).
 * Sleep timer turns off display after 10 seconds of no input, wakes on any button press.
+* A clock, which obtains time from an NTP server on boot.
 * Automatic light/dark modes based on time of day.
-* **EXPERIMENTAL:** Support for camera entities.
+* Support for camera entities.
 
 # Tools
 
@@ -62,9 +63,26 @@ Copy the `.UF2` file that you obtained for this project to the root of the drive
 
 Next, open the following files in the text editor of your choice: `config.py` and `secrets.py`.
 
-In `secrets.py`, you need to provide the SSID and password for your WiFi network, and the long-lived access token for your Home Assistant instance. Instructions on generating such tokens can be found [here](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token).
+In `secrets.py`, you need to provide:
 
-In `config.py`, you need to provide the URL to your Home Assistant instance, as well as a dictionary that defines the "areas" you wish to control. This does not map to the concept of Areas in Home Assistant, as that functionality is not exposed via the HA API; instead, think of these as pages on the display which you can cycle through.
+* The SSID and password for your WiFi network.
+* The long-lived access token for your Home Assistant instance. 
+  * Instructions on generating such tokens can be found [here](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token).
+
+In `config.py`, you need to provide:
+
+* Your timezone, in UTC offset:
+  * For example: EST would be -5, GMT would be 0, NPT would be 5.75, etc.
+* Whether your timezone uses DST, and if so:
+  * The start date of DST in your timezone.
+  * The end date of DST in your timezone.
+  * The number of hours shifted during DST (in most of the world this would be 1, in rare cases it may be a fraction e.g. 0.5).
+* The base URL of your Home Assistant instance.
+* Area configuration; see below.
+
+## Area Config
+
+`config.py` contains a dictionary that defines the "areas" you wish to control. This does not map to the concept of Areas in Home Assistant, as that functionality is not exposed via the HA API; instead, think of these as pages on the display which you can cycle through.
 
 Each area can support controlling up to three devices in Home Assistant (the Display Pack has 4 buttons, so 3 can be used to control devices, the fourth button is used to switch areas). The value for each Area key is a nested array of dictionaries that define the entity ID and toggle service for each device in the area. 
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,18 @@
+# NTP Config:
+# NTP time server:
+ntp_host = "pool.ntp.org"
+# Your timezone's offset from UTC in hours:
+# (e.g. GMT = 0.0, EST = -5.0, CET = 1.0, NPT = 5.75, etc.)
+utc_offset = 0.0
+# True if DST is observed by your timezone, otherwise False.
+dst_enabled = True
+# Daylight savings time start/end dates:
+dst_start = (2022, 03, 27, 1, 0, 0, 0, 0, 0)
+dst_end = (2022, 10, 30, 2, 0, 0, 0, 0, 0)
+# Number of hours shifted during DST:
+dst_shift = 1.0
+
+# Home Assistant config:
 # Update this to point to your HA url.
 ha_instance = "http://your-home-assistant-instance:8123"
 # Example config, replace this with your desired layout.

--- a/src/display.py
+++ b/src/display.py
@@ -2,7 +2,8 @@ import icons
 import gc
 import jpegdec
 from picographics import PicoGraphics, DISPLAY_PICO_DISPLAY_2
-import time
+import utils
+import utime
 
 class Display:
 
@@ -17,28 +18,28 @@ class Display:
       self.display.set_backlight(0.5)
       
   def getHeaderFontPen(self):
-      now = time.localtime(time.time())
+      now = utime.localtime(utime.time())
       if now[3] >= 7 and now[3] <= 20:
           return self.display.create_pen(225, 225, 225)          
       else:
           return self.display.create_pen(33, 33, 33)
     
   def getFontPen(self):
-      now = time.localtime(time.time())
+      now = utime.localtime(utime.time())
       if now[3] >= 7 and now[3] <= 20:
           return self.display.create_pen(33, 33, 33)
       else:
           return self.display.create_pen(225, 225, 225)
         
   def getBgPen(self):
-      now = time.localtime(time.time())      
+      now = utime.localtime(utime.time())      
       if now[3] >= 7 and now[3] <= 20:
           return self.display.create_pen(250, 250, 250)
       else:
           return self.display.create_pen(17, 17, 17)
     
   def getHeaderPen(self):
-      now = time.localtime(time.time())      
+      now = utime.localtime(utime.time())      
       if now[3] >= 7 and now[3] <= 20:
           return self.display.create_pen(3, 169, 244)
       else:
@@ -71,13 +72,15 @@ class Display:
       self.display.update()
   
   def drawBackground(self, areaName):
+      timeString = utils.getTimeString()
       self.isAsleep = False
       self.display.set_pen(self.getHeaderPen())
       self.display.rectangle(0, 0, self.width, 50)
-      self.display.set_pen(self.whitePen)
-      self.display.text(areaName, self.getCentreTextPosition(areaName), 20, 240, 2)
       self.display.set_pen(self.getBgPen())
       self.display.rectangle(0, 50, self.width, self.height - 50)
+      self.display.set_pen(self.whitePen)
+      self.display.text(areaName, self.getCentreTextPosition(areaName), 20, 240, 2)
+      self.display.text(timeString, self.width - self.display.measure_text(timeString, 2) - 10, 20, 240, 2)
       self.display.update()
 
   def drawDevice(self, button, device, on):
@@ -110,6 +113,7 @@ class Display:
       
   def renderCamera(self, areaName, imagePath):
       self.isAsleep = False
+      timeString = utils.getTimeString()
       xLabel = int(self.width - self.width / 2 - int(self.display.measure_text(areaName, 2) / 2))
       if imagePath is not None:
           try:
@@ -123,8 +127,9 @@ class Display:
               self.display.update()
       self.display.set_pen(self.whitePen)
       self.display.text(areaName, self.getCentreTextPosition(areaName), 200, 240, 2)
-      self.display.update()
-      
+      self.display.text(timeString, self.width - self.display.measure_text(timeString, 2) - 10, 200, 240, 2)      
+      self.display.update()    
+
   def getCentreTextPosition(self, text):
       return int(self.width - self.width / 2 - int(self.display.measure_text(text, 2) / 2))
       

--- a/src/ntp.py
+++ b/src/ntp.py
@@ -1,0 +1,39 @@
+import config
+import machine
+import usocket
+import ustruct
+import utime
+
+def setTime():
+    ntpHost = config.ntp_host        
+    query = bytearray(48)
+    query[0] = 0x1B
+    address = usocket.getaddrinfo(ntpHost, 123)[0][-1]
+    sock = usocket.socket(usocket.AF_INET, usocket.SOCK_DGRAM)    
+    try:
+        sock.settimeout(1)
+        response = sock.sendto(query, address)
+        message = sock.recv(48)
+    except:
+        # NTP server timed out; reboot and try again
+        machine.reset()
+    finally:
+        sock.close()
+    now = ustruct.unpack("!I", message[40:44])[0]
+    # Difference between NTP epoch & Unix epoch: (70*365 + 17)*86400
+    delta = 2208988800
+    # Flip negative/positive as we are subtracting from an offset
+    offset = config.utc_offset * -1
+    start = utime.mktime(config.dst_start)
+    end = utime.mktime(config.dst_end)
+    if config.dst_enabled and (now - delta) < start:
+        # Before DST, no shifting
+        delta = delta + (int(offset * 3600))
+    elif config.dst_enabled and (now - delta) < end:
+        # DST, subtract DST shift multiplier from offset
+        delta = delta + (int((offset * 3600)) - (int(config.dst_shift * 3600)))
+    else:
+        # After DST or DST not observed, no shifting
+        delta = delta + (int(offset * 3600))
+    utc = utime.gmtime((now - delta))
+    machine.RTC().datetime((utc[0], utc[1], utc[2], utc[6]+1, utc[3], utc[4], utc[5], 0))

--- a/src/ntp.py
+++ b/src/ntp.py
@@ -35,5 +35,5 @@ def setTime():
     else:
         # After DST or DST not observed, no shifting
         delta = delta + (int(offset * 3600))
-    utc = utime.gmtime((now - delta))
-    machine.RTC().datetime((utc[0], utc[1], utc[2], utc[6]+1, utc[3], utc[4], utc[5], 0))
+    local = utime.gmtime((now - delta))
+    machine.RTC().datetime((local[0], local[1], local[2], local[6]+1, local[3], local[4], local[5], 0))

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+import utime
 
 def fileExists(path):
     try:
@@ -11,6 +12,10 @@ def firstOrDefault(sequence, selector, default=None):
         if selector(s):
             return s
     return default
+
+def getTimeString():
+    time = utime.localtime(utime.time())
+    return f"{time[3]:02}:{time[4]:02}"
 
 def take(sequence, amount):
     amount += 1

--- a/src/wlan.py
+++ b/src/wlan.py
@@ -1,4 +1,5 @@
 import network
+import ntp
 import secrets
 import time
 
@@ -8,3 +9,4 @@ def connect():
     wlan.connect(secrets.ssid, secrets.password)
     while not wlan.isconnected():
         time.sleep(1)
+    ntp.setTime()


### PR DESCRIPTION
Obtains time from an NTP server on boot. If the request times out, the pico will reboot until successful. Timezone, DST, etc can all be configured in `config.py`.

Now that the time is reliably obtained, dark/light modes should work properly!

Also added a clock to the main display.