### PR TITLE
Fixed crash scenario

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -81,7 +81,7 @@ class App:
             self.display.sleep()
 
 app = App()
-app.refreshDevices()
+app.refreshArea()
 lastUse = utime.ticks_ms()
 
 while True:    


### PR DESCRIPTION
Fixed issue where device locks up if first view in the dictionary is a camera. Caused by init code always assuming device view.